### PR TITLE
修复因未启用严格模式导致服务器启动失败的问题

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www"
+    "start": "node --use-strict ./bin/www"
   },
   "dependencies": {
     "body-parser": "~1.15.1",


### PR DESCRIPTION
本地node版本：v4.4.5，直接按README.md说明在server目录下执行npm run start会报错：
Uncaught SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
经检查是由于server/routes/data.js中使用了let关键字，但并未在data.js文件头部添加'use strict'声明。
解决方法是按照上述提示信息，在server/package.json中将scripts.start脚本内容由“node ./bin/www”修改为“node --use-strict ./bin/www”。